### PR TITLE
Fix ContainerInfo.ApplyTo logic error

### DIFF
--- a/ItemChanger.Core/Containers/ContainerInfo.cs
+++ b/ItemChanger.Core/Containers/ContainerInfo.cs
@@ -132,7 +132,7 @@ public class ContainerInfo
     public void ApplyTo(GameObject obj)
     {
         ContainerInfoComponent component = obj.GetComponent<ContainerInfoComponent>();
-        if (component == null)
+        if (component != null)
         {
             throw new InvalidOperationException(
                 $"Only one {nameof(ContainerInfo)} may be applied to a given GameObject."


### PR DESCRIPTION
Looks like a typo. Function should throw when there is already a `ContainerInfoComponent` attached to the game object.